### PR TITLE
Fix wording of 'Glean Slack app' to adhere to Slack reviewer's feedback.

### DIFF
--- a/docs/docs/project-management/slack-integration.md
+++ b/docs/docs/project-management/slack-integration.md
@@ -9,7 +9,7 @@ automated reports to keep your team up to date with important metrics.
 1. Go to the [`Settings`]({{ glean_url }}/app/p/settings#integrations){:target="\_blank"} page using the link in the project dropdown
 2. Select `Integrations`
 3. Under the `Slack` subsection, click `Add to Slack`
-4. Click `Allow` on the next page to authorize the Glean Slack app to access your Slack workspace
+4. Click `Allow` on the next page to authorize the Glean app for Slack to access your Slack workspace
 5. Click `Return to Settings` on the next page to return to Glean
 
 ## Sharing to Slack


### PR DESCRIPTION
Slack is apparently very particular about how we word this:

> To meet our brand guidelines, please change `the Glean Slack app` on your landing page to `the Glean app for Slack`. This is a non-blocking issue but we will check to make sure this change is made on your next resubmission.