### PR TITLE
Put 'direct links' in info callouts.

### DIFF
--- a/docs/docs/data-modeling/Data-Models-Overview.md
+++ b/docs/docs/data-modeling/Data-Models-Overview.md
@@ -1,4 +1,4 @@
-[Direct link to your Glean Data Models]({{ glean_url }}/app/p/data-models)
+!!! info "[Direct link to your Glean Data Models]({{ glean_url }}/app/p/data-models)"
 
 Data models in Glean allow you to define how your organization will measure, track and explore data. Defining the logic for your analytics upfront allows your users to dig in and analyze data without writing code or worrying about whether they can trust their results. This declarative workflow allows the analyst and data team to manage how you think about your business and Glean will build a user interface automatically that helps you explore that data.
 

--- a/docs/docs/project-management/users-and-permissions.md
+++ b/docs/docs/project-management/users-and-permissions.md
@@ -4,7 +4,7 @@ You can invite members to your project in Glean to allow them to query and explo
 
 ## Add a user
 
-[Direct link to your Glean user list]({{ glean_url }}/app/p/people)
+!!! info "[Direct link to your Glean user list]({{ glean_url }}/app/p/people)"
 
 1. Go to the [`People`]({{ glean_url }}/app/p/people){:target="\_blank"} page using the link in the project dropdown
 2. Select `Users`
@@ -23,12 +23,12 @@ You can invite members to your project in Glean to allow them to query and explo
 
 There are four roles in Glean with increasing levels of permissions.
 
-| Role         | Description                                                                                                                                    |
-| ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Owner        | Owners can manage members in a project and manage data connections and manage data connection credentials.                                     |
-| Editor       | Editors can manage data models, both creating and editing existing data models.                                                                |
+| Role         | Description                                                                                                |
+| ------------ | ---------------------------------------------------------------------------------------------------------- |
+| Owner        | Owners can manage members in a project and manage data connections and manage data connection credentials. |
+| Editor       | Editors can manage data models, both creating and editing existing data models.                            |
 | Collaborator | Collaborators can interact with shared views, query data sources, explore data and create new saved views. |
-| Viewer       | Viewers can interact with shared views, query data sources, and explore data.                                |
+| Viewer       | Viewers can interact with shared views, query data sources, and explore data.                              |
 
 ## Modifying roles
 


### PR DESCRIPTION
These "direct link" blocks look sort of out of place and hacky. We should probably be using callouts for these.

Check out [here](https://docs.glean.io/rc-calder-info-callout/docs/project-management/users-and-permissions/) and [here](https://docs.glean.io/rc-calder-info-callout/docs/data-modeling/Data-Models-Overview/) to view the changes.

Before:

<img width="706" alt="image" src="https://user-images.githubusercontent.com/112495873/236559486-c236fe29-cc3f-41d2-b027-e9cad9547925.png">

After:
<img width="904" alt="image" src="https://user-images.githubusercontent.com/112495873/236559540-3b1bec77-1f3e-4e6b-830d-953ce9f25a0f.png">

