### PR TITLE
[GL-4401] Remove duplicate database connections page in docs site in favor of 'Database Connections -> Overview' page.

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,8 +97,6 @@ nav:
           - Project Invite Links: docs/project-management/invite-links.md
           - Users and Permissions: docs/project-management/users-and-permissions.md
           - Single Sign-On: docs/project-management/single-sign-on.md
-          # we should delete this eventually, just kept for backwards compatibility in links to our docs
-          - Database Connections: docs/database-connections/index.md
           - Sandbox Demo Projects: docs/project-management/demo-projects.md
           - Partner Projects: docs/project-management/partner-projects.md
       - Support:


### PR DESCRIPTION
Two places link to the same doc right now: `Database Connections -> Overview` and `Project Management -> Database Connections`. I removed the latter in favor of the former.

You can test this change [here](https://docs.glean.io/rc-calder-db-con/docs/database-connections/).